### PR TITLE
Pin protobuf and grpc abseil to 20250127.0

### DIFF
--- a/grpc/all/conanfile.py
+++ b/grpc/all/conanfile.py
@@ -104,7 +104,7 @@ class GrpcConan(ConanFile):
         # abseil is public. See https://github.com/conan-io/conan-center-index/pull/17284#issuecomment-1526082638
         if Version(self.version) >= "1.62.0":
             self.requires("protobuf/5.27.0", transitive_headers=True)
-            self.requires("abseil/[>=20240116.1 <=20250127.0]", transitive_headers=True)
+            self.requires("abseil/20250127.0", transitive_headers=True)
         else:
             self.requires("abseil/[>=20230125.3 <=20230802.1]", transitive_headers=True)
             self.requires("protobuf/3.21.12", transitive_headers=True)

--- a/protobuf/all/conanfile.py
+++ b/protobuf/all/conanfile.py
@@ -79,7 +79,7 @@ class ProtobufConan(ConanFile):
             self.requires("zlib/[>=1.2.11 <2]")
 
         if self._protobuf_release >= "22.0":
-            self.requires("abseil/[>=20230802.1 <=20250127.0]", transitive_headers=True)
+            self.requires("abseil/20250127.0", transitive_headers=True)
 
     def validate(self):
         if self.options.shared and is_msvc_static_runtime(self):


### PR DESCRIPTION
## Summary
- Pin protobuf 5.27.0 abseil dependency from range `[>=20230802.1 <=20250127.0]` to exact `20250127.0`
- Pin grpc 1.67.1 abseil dependency from range `[>=20240116.1 <=20250127.0]` to exact `20250127.0`
- Resolves abseil version conflict between protobuf and opentelemetry-cpp 1.23.0 (which pins abseil to `20250127.0`)

## Test plan
- [ ] Verify Conan dependency resolution succeeds with protobuf 5.27.0 + opentelemetry-cpp 1.23.0
- [ ] Build Milvus with the updated recipes to confirm no abseil conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)