### PR TITLE
fix: libavrocpp - support fmt compiled mode (fmt::fmt)

### DIFF
--- a/libavrocpp/all/conanfile.py
+++ b/libavrocpp/all/conanfile.py
@@ -38,13 +38,16 @@ class LibavrocppConan(ConanFile):
     def requirements(self):
         self.requires("boost/[>=1.81.0 <=1.89.0]", transitive_headers=True)
         self.requires("snappy/[>=1.1.9 <2]")
-        self.requires("fmt/[>=12 <13]", transitive_headers=True)
+        self.requires("fmt/[>=9]", transitive_headers=True)
         self.requires("zlib/[>=1.3.1 <2]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
         replace_in_file(self, os.path.join(self.source_folder, "lang", "c++", "CMakeLists.txt"),
                         "-Werror", "")
+        # fmt >= 10 uses compiled target (fmt::fmt) instead of header-only (fmt::fmt-header-only)
+        replace_in_file(self, os.path.join(self.source_folder, "lang", "c++", "CMakeLists.txt"),
+                        "fmt::fmt-header-only", "fmt::fmt")
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -55,7 +58,6 @@ class LibavrocppConan(ConanFile):
         tc.generate()
 
         deps = CMakeDeps(self)
-        deps.set_property("fmt", "cmake_target_aliases", ["fmt::fmt-header-only"])
         deps.generate()
 
     def build(self):


### PR DESCRIPTION
## Problem

When `fmt >= 10` is used in compiled mode (`header_only: False`), the CMake target is `fmt::fmt` instead of `fmt::fmt-header-only`. The avro C++ `CMakeLists.txt` hard-codes `fmt::fmt-header-only`, causing build failures:

```
CMake Error at CMakeLists.txt:151 (target_link_libraries):
  Target "avrocpp_s" links to:
    fmt::fmt-header-only
  but the target was not found.
```

This was triggered by upgrading fmt from `9.1.0` (header-only) to `11.0.2` (compiled) in milvus: milvus-io/milvus#48149

## Fix

- Patch avro's `CMakeLists.txt` at build time to replace `fmt::fmt-header-only` with `fmt::fmt`
- Relax fmt version requirement from `>=12 <13` to `>=9` to allow fmt 11.x
- Remove the non-functional `cmake_target_aliases` workaround