### PR TITLE
fix: disable libsystemd in gRPC recipe by default

### DIFF
--- a/grpc/all/conanfile.py
+++ b/grpc/all/conanfile.py
@@ -53,7 +53,7 @@ class GrpcConan(ConanFile):
         "python_plugin": True,
         "ruby_plugin": True,
         "secure": False,
-        "with_libsystemd": True
+        "with_libsystemd": False
     }
 
     short_paths = True


### PR DESCRIPTION
## Summary
Disable `with_libsystemd` default in gRPC recipe (True → False).

## Motivation
When OpenSSL is switched from static to dynamic linking in milvus (milvus-io/milvus#48293), conan package hashes change, triggering rebuilds of gRPC and opentelemetry-cpp. The gRPC rebuild fails because conan's `cmakedeps` generator cannot find `libsystemd` as a conan package in CI.

Milvus does not use gRPC's systemd integration, so disabling it is safe.

## Impact
- gRPC package no longer requires libsystemd conan package
- All downstream packages (opentelemetry-cpp, knowhere, milvus-storage, milvus-common) work without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)