### PR TITLE
fix: add RPATH and LD_LIBRARY_PATH for shared protobuf in grpc/otel builds

### DIFF
--- a/opentelemetry-cpp/all/conanfile.py
+++ b/opentelemetry-cpp/all/conanfile.py
@@ -334,6 +334,23 @@ class OpenTelemetryCppConan(ConanFile):
 
         apply_conandata_patches(self)
 
+        # When protobuf/grpc are shared, grpc_cpp_plugin needs LD_LIBRARY_PATH
+        # to find libprotoc.so at build time. Patch the proto cmake to wrap
+        # protoc invocations with the library path, similar to gRPC's own recipe.
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            protos_cmake_path = os.path.join(
+                self.source_folder, "cmake", "opentelemetry-proto.cmake"
+            )
+            replace_in_file(
+                self,
+                protos_cmake_path,
+                "${PROTOBUF_PROTOC_EXECUTABLE} ${PROTOBUF_COMMON_FLAGS}",
+                '${CMAKE_COMMAND} -E env '
+                '"LD_LIBRARY_PATH=$<JOIN:${CMAKE_LIBRARY_PATH},:>:$ENV{LD_LIBRARY_PATH}" '
+                '${PROTOBUF_PROTOC_EXECUTABLE} ${PROTOBUF_COMMON_FLAGS}',
+                strict=False,
+            )
+
     def build(self):
         self._patch_sources()
         cmake = CMake(self)


### PR DESCRIPTION
## Summary
Follow-up to #95. When conan rebuilds packages from source (e.g. Debug+ASAN mode), `grpc_cpp_plugin` fails to find `libprotoc.so` because conan cache paths aren't in `LD_LIBRARY_PATH`.

- **gRPC**: set `CMAKE_INSTALL_RPATH` on installed binaries so plugins embed dependency lib paths
- **opentelemetry-cpp**: wrap protoc invocations with `LD_LIBRARY_PATH` injection (same approach gRPC uses for its own builds)

## Context
- milvus-io/milvus#48293 switches OpenSSL to shared linking
- This causes conan package hash changes, triggering `--build=missing` rebuilds
- Debug+ASAN builds have no cached packages, so everything rebuilds from source
- `grpc_cpp_plugin` dynamically links `libprotoc.so` but has no RPATH → crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)