### PR TITLE
fix(folly): add libaio to system_libs for Linux

### DIFF
--- a/folly/all/conanfile.py
+++ b/folly/all/conanfile.py
@@ -246,7 +246,7 @@ class FollyConan(ConanFile):
             self.cpp_info.components["libfolly"].requires.append("libdwarf::libdwarf")
         if self.settings.os == "Linux":
             self.cpp_info.components["libfolly"].requires.extend(["libiberty::libiberty", "libunwind::libunwind"])
-            self.cpp_info.components["libfolly"].system_libs.extend(["pthread", "dl", "rt"])
+            self.cpp_info.components["libfolly"].system_libs.extend(["pthread", "dl", "rt", "aio"])
 
         if Version(self.version) >= "2020.08.10.00":
             self.cpp_info.components["libfolly"].requires.append("fmt::fmt")

--- a/folly/v2024/conanfile.py
+++ b/folly/v2024/conanfile.py
@@ -262,7 +262,7 @@ class FollyConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libfolly"].requires.extend(["libiberty::libiberty", "libunwind::libunwind"])
         if self.settings.os == "Linux":
-            self.cpp_info.components["libfolly"].system_libs.extend(["pthread", "dl", "rt"])
+            self.cpp_info.components["libfolly"].system_libs.extend(["pthread", "dl", "rt", "aio"])
             self.cpp_info.components["libfolly"].defines.extend(["FOLLY_HAVE_ELF", "FOLLY_HAVE_DWARF"])
         elif self.settings.os == "Windows":
             self.cpp_info.components["libfolly"].system_libs.extend(["ws2_32", "iphlpapi", "crypt32"])


### PR DESCRIPTION
Folly's AsyncIO uses libaio functions (io_submit, io_getevents, io_queue_init, io_queue_release), but libaio was not declared as a system library dependency in package_info(). This causes undefined reference errors at link time for consumers like milvus-storage.

Add "aio" to system_libs under the existing Linux-only condition for both the legacy recipe (folly/all) and the v2024 recipe (folly/v2024).