### PR TITLE
Add milvus-sdk-cpp 2.6.4-rc1

### DIFF
--- a/recipes/milvus-sdk-cpp/all/conandata.yml
+++ b/recipes/milvus-sdk-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.4-rc1":
+    url: "https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v2.6.4-rc1.tar.gz"
+    sha256: "a3ca860b71a174929bdc5c3faf45aa5bfb89683f7c93089e100f1c20dce73b0b"
   "2.6.3":
     url: "https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v2.6.3.tar.gz"
     sha256: "e5f1041cc6b17a2b0667eab32b44e49ad09bd663462a2f94c29c12a68563cba1"

--- a/recipes/milvus-sdk-cpp/config.yml
+++ b/recipes/milvus-sdk-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.4-rc1":
+    folder: all
   "2.6.3":
     folder: all
   "2.6.2":


### PR DESCRIPTION
## Summary
- Add `milvus-sdk-cpp/2.6.4-rc1@milvus/dev`.
- Source repo: `milvus-io/milvus-sdk-cpp`.
- Source tag: `v2.6.4-rc1`.
- Source commit: `54fc6a7b0668f44a4d90b4fbc6accb025d0172b5`.
- Source URL: `https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v2.6.4-rc1.tar.gz`.
- Source SHA256: `a3ca860b71a174929bdc5c3faf45aa5bfb89683f7c93089e100f1c20dce73b0b`.

## Validation
- `git diff --check`
- `conan export recipes/milvus-sdk-cpp/all/conanfile.py --version=2.6.4-rc1 --user=milvus --channel=dev`