### PR TITLE
Add milvus-sdk-cpp 2.6.4-rc1

### DIFF
--- a/recipes/milvus-sdk-cpp/all/conandata.yml
+++ b/recipes/milvus-sdk-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.4-rc1":
+    url: "https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v2.6.4-rc1.tar.gz"
+    sha256: "e38e5285545fba35c312c70d0bf60ad9a0bd3d0f3c8a22954e754526b4ef30a5"
   "2.6.3":
     url: "https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v2.6.3.tar.gz"
     sha256: "e5f1041cc6b17a2b0667eab32b44e49ad09bd663462a2f94c29c12a68563cba1"

--- a/recipes/milvus-sdk-cpp/config.yml
+++ b/recipes/milvus-sdk-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.4-rc1":
+    folder: all
   "2.6.3":
     folder: all
   "2.6.2":


### PR DESCRIPTION
## Summary
- Add `milvus-sdk-cpp/2.6.4-rc1@milvus/dev`.
- Source repo: `milvus-io/milvus-sdk-cpp`.
- Source tag: `v2.6.4-rc1`.
- Source commit: `f7fa31d357e5e147cdc6810a0126288657b1b0da`.
- Source URL: `https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v2.6.4-rc1.tar.gz`.
- Source SHA256: `e38e5285545fba35c312c70d0bf60ad9a0bd3d0f3c8a22954e754526b4ef30a5`.
- Verification C++ standard: `14`.

<!-- recipe-verify-cppstd=14 -->

## Validation
- `git diff --check`
- `conan export recipes/milvus-sdk-cpp/all/conanfile.py --version=2.6.4-rc1 --user=milvus --channel=dev`