### PR TITLE
feat: add libbson 1.30.6 recipe (libbson-only, no libmongoc)

### DIFF
--- a/recipes/libbson/all/conandata.yml
+++ b/recipes/libbson/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.30.6":
+    url: "https://github.com/mongodb/mongo-c-driver/releases/download/1.30.6/mongo-c-driver-1.30.6.tar.gz"
+    sha256: "831ddb54d1cd2ae080548ff3febdbc5a68a4938ef932e442269bf6b11af871b8"

--- a/recipes/libbson/all/conanfile.py
+++ b/recipes/libbson/all/conanfile.py
@@ -1,0 +1,112 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+
+required_conan_version = ">=1.53.0"
+
+
+class LibbsonConan(ConanFile):
+    name = "libbson"
+    description = (
+        "libbson: the BSON serialization library from the MongoDB C driver, "
+        "built WITHOUT libmongoc (no networking/SASL/TLS, no utf8proc)."
+    )
+    license = "Apache-2.0"
+    url = "https://github.com/milvus-io/conanfiles"
+    homepage = "https://github.com/mongodb/mongo-c-driver"
+    topics = ("bson", "mongodb", "serialization", "json")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": True,
+        "fPIC": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        # libbson is a pure C library: its package id must not depend on C++ settings.
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        # Build libbson ONLY — never libmongoc (which is what drags in utf8proc,
+        # OpenSSL, SASL, etc.).
+        tc.cache_variables["ENABLE_MONGOC"] = "OFF"
+        tc.cache_variables["ENABLE_BSON"] = "ON"
+        tc.cache_variables["ENABLE_SHARED"] = self.options.shared
+        tc.cache_variables["ENABLE_STATIC"] = not self.options.shared
+        tc.cache_variables["ENABLE_TESTS"] = "OFF"
+        tc.cache_variables["ENABLE_EXAMPLES"] = "OFF"
+        tc.cache_variables["ENABLE_MAN_PAGES"] = "OFF"
+        tc.cache_variables["ENABLE_HTML_DOCS"] = "OFF"
+        tc.cache_variables["ENABLE_MAINTAINER_FLAGS"] = "OFF"
+        tc.cache_variables["ENABLE_UNINSTALL"] = "OFF"
+        tc.cache_variables["ENABLE_EXTRA_ALIGNMENT"] = "ON"
+        tc.cache_variables["ENABLE_AUTOMATIC_INIT_AND_CLEANUP"] = "ON"
+        tc.cache_variables["ENABLE_PIC"] = self.options.get_safe("fPIC", True)
+        tc.cache_variables["BUILD_VERSION"] = self.version
+        # Avoid installing VC runtime stuff on Windows.
+        tc.variables["CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP"] = "TRUE"
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "COPYING",
+             src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "THIRD_PARTY_NOTICES",
+             src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        # Match libbson's native CMake config name (bson-1.0) and target
+        # (mongo::bson_shared / mongo::bson_static) so consumers can find_package
+        # it exactly as they would the upstream package.
+        self.cpp_info.set_property("cmake_file_name", "bson-1.0")
+        lib_type = "shared" if self.options.shared else "static"
+        self.cpp_info.set_property("cmake_target_name", f"mongo::bson_{lib_type}")
+        self.cpp_info.set_property(
+            "cmake_target_aliases", [f"bson::{lib_type}", "libbson::libbson"])
+        self.cpp_info.set_property(
+            "pkg_config_name",
+            "libbson-1.0" if self.options.shared else "libbson-static-1.0")
+
+        if self.options.shared:
+            self.cpp_info.libs = ["bson-1.0"]
+        else:
+            self.cpp_info.libs = ["bson-static-1.0"]
+            self.cpp_info.defines = ["BSON_STATIC"]
+
+        self.cpp_info.includedirs = [os.path.join("include", "libbson-1.0")]
+
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs = ["m", "pthread", "rt"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["ws2_32"]

--- a/recipes/libbson/all/test_package/CMakeLists.txt
+++ b/recipes/libbson/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(bson-1.0 REQUIRED CONFIG)
+
+add_executable(test_package test_package.c)
+# libbson::libbson is an alias exposed for both shared and static builds.
+target_link_libraries(test_package PRIVATE libbson::libbson)

--- a/recipes/libbson/all/test_package/conanfile.py
+++ b/recipes/libbson/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libbson/all/test_package/test_package.c
+++ b/recipes/libbson/all/test_package/test_package.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+#include <bson/bson.h>
+
+int
+main(void) {
+    bson_t *doc = bson_new();
+    bson_append_utf8(doc, "hello", -1, "world", -1);
+    bson_append_int32(doc, "answer", -1, 42);
+
+    char *json = bson_as_relaxed_extended_json(doc, NULL);
+    printf("libbson ok: %s\n", json ? json : "(null)");
+    bson_free(json);
+    bson_destroy(doc);
+    return 0;
+}

--- a/recipes/libbson/config.yml
+++ b/recipes/libbson/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.30.6":
+    folder: "all"


### PR DESCRIPTION
Adds a **libbson** recipe that builds ONLY the BSON C library from
mongo-c-driver 1.30.6 (`ENABLE_MONGOC=OFF`), dropping libmongoc and its
utf8proc / OpenSSL / SASL dependencies.

Used by milvus core for JSON BSON (de)serialization in place of the
bsoncxx C++ driver (which transitively pulled in libmongoc + utf8proc and
failed to build under newer clang/CMake on macOS arm64).

- `cmake_file_name`: `bson-1.0`
- target: `mongo::bson_shared` (alias `libbson::libbson`)
- recipe revision: `4fc4c269cbda1b46c3118fa396cdc690`
- already built & published to **testing2** (run 27711466945, green; test_package passes)

Merging this to master auto-publishes `libbson/1.30.6@milvus/dev` to production via publish-merged-recipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)