### PR TITLE
Add milvus-common 1.0.0-242deda

### DIFF
--- a/recipes/milvus-common/all/conandata.yml
+++ b/recipes/milvus-common/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0-242deda":
+    url: "https://github.com/zilliztech/milvus-common/archive/refs/tags/v1.0.0-242deda.tar.gz"
+    sha256: "c697662f22f99ba40d507fd51e8d66dca7bde36eba19a1998bacd6b25e12d64e"
   "1.0.0-6476f50":
     url: "https://github.com/zilliztech/milvus-common/archive/refs/tags/v1.0.0-6476f50.tar.gz"
     sha256: "b0d5b42c8aec53c5198ace3eec94a1b153fd0940bcdf8a6c23c20bc3a80af3e5"

--- a/recipes/milvus-common/config.yml
+++ b/recipes/milvus-common/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0-242deda":
+    folder: all
   "1.0.0-6476f50":
     folder: all
   "1.0.0-1929351":


### PR DESCRIPTION
## Summary
- Add `milvus-common/1.0.0-242deda@milvus/dev`.
- Source repo: `zilliztech/milvus-common`.
- Source tag: `v1.0.0-242deda`.
- Source commit: `242dedaaa2af86f1c070872cc75cc62e58e1882f`.
- Source URL: `https://github.com/zilliztech/milvus-common/archive/refs/tags/v1.0.0-242deda.tar.gz`.
- Source SHA256: `c697662f22f99ba40d507fd51e8d66dca7bde36eba19a1998bacd6b25e12d64e`.
- Verification C++ standard: `20`.

<!-- recipe-verify-cppstd=20 -->

## Validation
- `git diff --check`
- `conan export recipes/milvus-common/all/conanfile.py --version=1.0.0-242deda --user=milvus --channel=dev`