### PR TITLE
Add milvus-sdk-cpp 2.6.4-rc2

### DIFF
--- a/recipes/milvus-sdk-cpp/all/conandata.yml
+++ b/recipes/milvus-sdk-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.4-rc2":
+    url: "https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v2.6.4-rc2.tar.gz"
+    sha256: "148bceffdd512655720af7d7e527c6516464f871bcd7ef90293855e2844ef01a"
   "3.0.0":
     url: "https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v3.0.0.tar.gz"
     sha256: "7f2584940990e0dae8fef749bba622337c980251b017cce4e2856f3791f35020"

--- a/recipes/milvus-sdk-cpp/config.yml
+++ b/recipes/milvus-sdk-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.4-rc2":
+    folder: all
   "3.0.0":
     folder: all
   "2.6.4":


### PR DESCRIPTION
## Summary
- Add `milvus-sdk-cpp/2.6.4-rc2@milvus/dev`.
- Source repo: `milvus-io/milvus-sdk-cpp`.
- Source tag: `v2.6.4-rc2`.
- Source commit: `e2f87955a0b7b34400cfdfaf7cff753a3052445a`.
- Source URL: `https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v2.6.4-rc2.tar.gz`.
- Source SHA256: `148bceffdd512655720af7d7e527c6516464f871bcd7ef90293855e2844ef01a`.
- Verification C++ standard: `14`.

<!-- recipe-verify-cppstd=14 -->

## Validation
- `git diff --check`
- `conan export recipes/milvus-sdk-cpp/all/conanfile.py --version=2.6.4-rc2 --user=milvus --channel=dev`