### PR TITLE
enhance: add arrow 17.0.0 parquet backport patches

### DIFF
--- a/recipes/arrow/all/conandata.yml
+++ b/recipes/arrow/all/conandata.yml
@@ -48,6 +48,15 @@ sources:
     url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-7.0.0/apache-arrow-7.0.0.tar.gz?action=download"
     sha256: "e8f49b149a15ecef4e40fcfab1b87c113c6b1ee186005c169e5cdf95d31a99de"
 patches:
+  "17.0.0":
+    - patch_file: "patches/17.0.0-0001-gh-47012-reserve-byte-array-flba.patch"
+      patch_description: "Backport GH-47012 reserve BYTE_ARRAY and FLBA readers correctly"
+      patch_type: "backport"
+      patch_source: "https://github.com/apache/arrow/pull/47013"
+    - patch_file: "patches/17.0.0-0002-gh-48112-plain-byte-array-estimate.patch"
+      patch_description: "Backport GH-48112 improve PLAIN BYTE_ARRAY data length estimate"
+      patch_type: "backport"
+      patch_source: "https://github.com/apache/arrow/pull/48113"
   "8.0.1":
     - patch_file: "patches/8.0.0-0005-install-utils.patch"
       patch_description: "enable utils installation"

--- a/recipes/arrow/all/patches/17.0.0-0001-gh-47012-reserve-byte-array-flba.patch
+++ b/recipes/arrow/all/patches/17.0.0-0001-gh-47012-reserve-byte-array-flba.patch
@@ -1,0 +1,39 @@
+diff --git a/cpp/src/parquet/column_reader.cc b/cpp/src/parquet/column_reader.cc
+index ebf9515f2760..d95ae9dff9 100644
+--- a/cpp/src/parquet/column_reader.cc
++++ b/cpp/src/parquet/column_reader.cc
+@@ -1791,7 +1791,7 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
+     }
+   }
+ 
+-  void ReserveValues(int64_t extra_values) {
++  virtual void ReserveValues(int64_t extra_values) {
+     const int64_t new_values_capacity =
+         UpdateCapacity(values_capacity_, values_written_, extra_values);
+     if (new_values_capacity > values_capacity_) {
+@@ -2075,6 +2075,13 @@ class FLBARecordReader final : public TypedRecordReader<FLBAType>,
+     return ::arrow::ArrayVector({std::move(chunk)});
+   }
+ 
++  void ReserveValues(int64_t extra_values) override {
++    TypedRecordReader::ReserveValues(extra_values);
++    PARQUET_THROW_NOT_OK(null_bitmap_builder_.Reserve(extra_values));
++    PARQUET_THROW_NOT_OK(
++        data_builder_.Reserve(extra_values * static_cast<int64_t>(byte_width_)));
++  }
++
+   void ReadValuesDense(int64_t values_to_read) override {
+     auto values = ValuesHead<FLBA>();
+     int64_t num_decoded =
+@@ -2156,6 +2163,11 @@ class ByteArrayChunkedRecordReader final : public TypedRecordReader<ByteArrayTyp
+     return result;
+   }
+ 
++  void ReserveValues(int64_t extra_values) override {
++    TypedRecordReader::ReserveValues(extra_values);
++    PARQUET_THROW_NOT_OK(accumulator_.builder->Reserve(extra_values));
++  }
++
+   void ReadValuesDense(int64_t values_to_read) override {
+     int64_t num_decoded = this->current_decoder_->DecodeArrowNonNull(
+         static_cast<int>(values_to_read), &accumulator_);

--- a/recipes/arrow/all/patches/17.0.0-0002-gh-48112-plain-byte-array-estimate.patch
+++ b/recipes/arrow/all/patches/17.0.0-0002-gh-48112-plain-byte-array-estimate.patch
@@ -1,0 +1,51 @@
+diff --git a/cpp/src/parquet/encoding.cc b/cpp/src/parquet/encoding.cc
+index 54e1e000040a..1c69c4e217 100644
+--- a/cpp/src/parquet/encoding.cc
++++ b/cpp/src/parquet/encoding.cc
+@@ -1510,31 +1510,39 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
+   Status DecodeArrowDense(int num_values, int null_count, const uint8_t* valid_bits,
+                           int64_t valid_bits_offset,
+                           typename EncodingTraits<ByteArrayType>::Accumulator* out,
+                           int* out_values_decoded) {
++    // We're going to decode up to `num_values - null_count` PLAIN values,
++    // and each value has a 4-byte length header that doesn't count for the
++    // Arrow binary data length.
++    int64_t estimated_data_length =
++        std::max<int64_t>(0, len_ - 4 * (num_values - null_count));
++
+     ArrowBinaryHelper<ByteArrayType> helper(out, num_values);
+     int values_decoded = 0;
+ 
+-    RETURN_NOT_OK(helper.Prepare(len_));
++    RETURN_NOT_OK(helper.Prepare(estimated_data_length));
+ 
+     int i = 0;
+     RETURN_NOT_OK(VisitNullBitmapInline(
+         valid_bits, valid_bits_offset, num_values, null_count,
+         [&]() {
+           if (ARROW_PREDICT_FALSE(len_ < 4)) {
+             ParquetException::EofException();
+           }
+           auto value_len = SafeLoadAs<int32_t>(data_);
+           if (ARROW_PREDICT_FALSE(value_len < 0 || value_len > INT32_MAX - 4)) {
+             return Status::Invalid("Invalid or corrupted value_len '", value_len, "'");
+           }
+           auto increment = value_len + 4;
+           if (ARROW_PREDICT_FALSE(len_ < increment)) {
+             ParquetException::EofException();
+           }
+-          RETURN_NOT_OK(helper.PrepareNextInput(value_len, len_));
++          RETURN_NOT_OK(helper.PrepareNextInput(value_len, estimated_data_length));
+           helper.UnsafeAppend(data_ + 4, value_len);
+           data_ += increment;
+           len_ -= increment;
++          estimated_data_length -= value_len;
++          DCHECK_GE(estimated_data_length, 0);
+           ++values_decoded;
+           ++i;
+           return Status::OK();
+         },
+         [&]() {
+           helper.UnsafeAppendNull();
+           ++i;
+           return Status::OK();


### PR DESCRIPTION
Backport two Arrow Parquet fixes for arrow/17.0.0@milvus/dev:

- GH-47012 reserves BYTE_ARRAY and FLBA reader builders correctly.

- GH-48112 improves the PLAIN BYTE_ARRAY data length estimate.

The patches are wired through conandata.yml so the recipe exports and applies them through the existing Conan patch flow.