### PR TITLE
Add milvus-sdk-cpp 2.6.5

### DIFF
--- a/recipes/milvus-sdk-cpp/all/conandata.yml
+++ b/recipes/milvus-sdk-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.5":
+    url: "https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v2.6.5.tar.gz"
+    sha256: "a021f38b86dc1158f99aeeeea19a173b6c662f84727d4a44ca3ac2823859e952"
   "3.0.0":
     url: "https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v3.0.0.tar.gz"
     sha256: "7f2584940990e0dae8fef749bba622337c980251b017cce4e2856f3791f35020"

--- a/recipes/milvus-sdk-cpp/config.yml
+++ b/recipes/milvus-sdk-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.5":
+    folder: all
   "3.0.0":
     folder: all
   "2.6.4":


### PR DESCRIPTION
## Summary
- Add `milvus-sdk-cpp/2.6.5@milvus/dev`.
- Source repo: `milvus-io/milvus-sdk-cpp`.
- Source tag: `v2.6.5`.
- Source commit: `771691a621b07478a1e693d3e6c6686ebb0fbdaa`.
- Source URL: `https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v2.6.5.tar.gz`.
- Source SHA256: `a021f38b86dc1158f99aeeeea19a173b6c662f84727d4a44ca3ac2823859e952`.
- Verification C++ standard: `14`.

<!-- recipe-verify-cppstd=14 -->

## Validation
- `git diff --check`
- `conan export recipes/milvus-sdk-cpp/all/conanfile.py --version=2.6.5 --user=milvus --channel=dev`