### PR TITLE
feat: Add aws-sdk-cpp 1.11.842 and update CRT dependencies

### DIFF
--- a/recipes/aws-c-auth/all/conandata.yml
+++ b/recipes/aws-c-auth/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.10.3":
+    url: "https://github.com/awslabs/aws-c-auth/archive/v0.10.3.tar.gz"
+    sha256: "20fc5e75529fadd81fd38b25f9d83798b53ab235ebbac92cdfbb716cfcc7593d"
   "0.9.1":
     url: "https://github.com/awslabs/aws-c-auth/archive/v0.9.1.tar.gz"
     sha256: "adae1e725d9725682366080b8bf8e49481650c436b846ceeb5efe955d5e03273"

--- a/recipes/aws-c-auth/all/conanfile.py
+++ b/recipes/aws-c-auth/all/conanfile.py
@@ -47,7 +47,13 @@ class AwsCAuth(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "0.9.1":
+        if Version(self.version) >= "0.10.3":
+            self.requires("aws-c-common/0.14.0", transitive_headers=True, transitive_libs=True)
+            self.requires("aws-c-cal/0.9.14")
+            self.requires("aws-c-io/0.27.0", transitive_headers=True, transitive_libs=True)
+            self.requires("aws-c-http/0.11.0", transitive_headers=True)
+            self.requires("aws-c-sdkutils/0.2.5", transitive_headers=True)
+        elif Version(self.version) >= "0.9.1":
             self.requires("aws-c-common/0.12.5", transitive_headers=True, transitive_libs=True)
             self.requires("aws-c-cal/0.9.8")
             self.requires("aws-c-io/0.23.2", transitive_headers=True, transitive_libs=True)

--- a/recipes/aws-c-auth/config.yml
+++ b/recipes/aws-c-auth/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.10.3":
+    folder: all
   "0.9.1":
     folder: all
   "0.7.8":

--- a/recipes/aws-c-cal/all/conandata.yml
+++ b/recipes/aws-c-cal/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.14":
+    url: "https://github.com/awslabs/aws-c-cal/archive/v0.9.14.tar.gz"
+    sha256: "0e96e0067fa921768e07b5b4ebad82011ccf474903e9286419ef428d68f317ea"
   "0.9.8":
     url: "https://github.com/awslabs/aws-c-cal/archive/v0.9.8.tar.gz"
     sha256: "4a2a0918c763639f18d971367df6b528a1f3a0660f1c66d5791e435e8e671db9"

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -48,7 +48,9 @@ class AwsCCal(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "0.9.8":
+        if Version(self.version) >= "0.9.14":
+            self.requires("aws-c-common/0.14.0", transitive_headers=True, transitive_libs=True)
+        elif Version(self.version) >= "0.9.8":
             self.requires("aws-c-common/0.12.5", transitive_headers=True, transitive_libs=True)
         elif Version(self.version) <= "0.5.20":
             self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)

--- a/recipes/aws-c-cal/all/test_package/conanfile.py
+++ b/recipes/aws-c-cal/all/test_package/conanfile.py
@@ -31,6 +31,7 @@ class TestPackageConan(ConanFile):
             stream = io.StringIO()
             bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
             self.run(bin_path, stream, env="conanrun")
-            self.output.info(stream.getvalue())
+            output = stream.getvalue()
+            self.output.info(output)
             if self._needs_openssl:
-                assert "found static libcrypto" in stream.getvalue()
+                assert "found static libcrypto" in output or "found weak ref libcrypto" in output

--- a/recipes/aws-c-cal/config.yml
+++ b/recipes/aws-c-cal/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.9.14":
+    folder: all
   "0.9.8":
     folder: all
   "0.6.9":

--- a/recipes/aws-c-common/all/conandata.yml
+++ b/recipes/aws-c-common/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.14.0":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.14.0.tar.gz"
+    sha256: "3684076ec5da899074336722ba58a01f7166a1a2e5ad72f846f6fd468ecdf2ec"
   "0.12.5":
     url: "https://github.com/awslabs/aws-c-common/archive/v0.12.5.tar.gz"
     sha256: "02d1ab905d43a33008a63f273b27dbe4859e9f090eac6f0e3eeaf8c64a083937"

--- a/recipes/aws-c-common/config.yml
+++ b/recipes/aws-c-common/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.14.0":
+    folder: all
   "0.12.5":
     folder: all
   "0.9.12":

--- a/recipes/aws-c-compression/all/conandata.yml
+++ b/recipes/aws-c-compression/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.3.2":
+    url: "https://github.com/awslabs/aws-c-compression/archive/v0.3.2.tar.gz"
+    sha256: "f93f5a5d8b3fee3a6d97b14ba279efacd4d4016ef9cc7dc4be7d43519ecfbe93"
   "0.3.1":
     url: "https://github.com/awslabs/aws-c-compression/archive/v0.3.1.tar.gz"
     sha256: "d89fca17a37de762dc34f332d2da402343078da8dbd2224c46a11a88adddf754"

--- a/recipes/aws-c-compression/all/conanfile.py
+++ b/recipes/aws-c-compression/all/conanfile.py
@@ -40,7 +40,9 @@ class AwsCCompression(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "0.3.1":
+        if Version(self.version) >= "0.3.2":
+            self.requires("aws-c-common/0.14.0", transitive_headers=True, transitive_libs=True)
+        elif Version(self.version) >= "0.3.1":
             self.requires("aws-c-common/0.12.5", transitive_headers=True, transitive_libs=True)
         elif Version(self.version) <= "0.2.15":
             self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)

--- a/recipes/aws-c-compression/config.yml
+++ b/recipes/aws-c-compression/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.3.2":
+    folder: all
   "0.3.1":
     folder: all
   "0.2.17":

--- a/recipes/aws-c-event-stream/all/conandata.yml
+++ b/recipes/aws-c-event-stream/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.7.1":
+    url: "https://github.com/awslabs/aws-c-event-stream/archive/v0.7.1.tar.gz"
+    sha256: "334b2abfe0cb5c68d79d52525598fdd5f6052b93a17a78a4b1ada7fa1be252c0"
   "0.5.7":
     url: "https://github.com/awslabs/aws-c-event-stream/archive/v0.5.7.tar.gz"
     sha256: "5d92abed2ed89cc1efaba3963e888d9df527296f1dbfe21c569f84ea731aa3c2"

--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -43,7 +43,10 @@ class AwsCEventStream(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "0.5.7":
+        if Version(self.version) >= "0.7.1":
+            self.requires("aws-c-common/0.14.0", transitive_headers=True, transitive_libs=True)
+            self.requires("aws-checksums/0.2.10")
+        elif Version(self.version) >= "0.5.7":
             self.requires("aws-c-common/0.12.5", transitive_headers=True, transitive_libs=True)
             self.requires("aws-checksums/0.2.6")
         elif Version(self.version) < "0.3.1":
@@ -52,7 +55,9 @@ class AwsCEventStream(ConanFile):
         else:
             self.requires("aws-c-common/0.9.6", transitive_headers=True, transitive_libs=True)
             self.requires("aws-checksums/0.1.17")
-        if Version(self.version) >= "0.5.7":
+        if Version(self.version) >= "0.7.1":
+            self.requires("aws-c-io/0.27.0")
+        elif Version(self.version) >= "0.5.7":
             self.requires("aws-c-io/0.23.2")
         elif Version(self.version) >= "0.2":
             if Version(self.version) < "0.2.11":

--- a/recipes/aws-c-event-stream/config.yml
+++ b/recipes/aws-c-event-stream/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.7.1":
+    folder: all
   "0.5.7":
     folder: all
   "0.3.2":

--- a/recipes/aws-c-http/all/conandata.yml
+++ b/recipes/aws-c-http/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.0":
+    url: "https://github.com/awslabs/aws-c-http/archive/v0.11.0.tar.gz"
+    sha256: "4ccbdd33c798b590288330dec9e93abe2ff6cfb198b7a4db036c9d362f2e6506"
   "0.10.5":
     url: "https://github.com/awslabs/aws-c-http/archive/v0.10.5.tar.gz"
     sha256: "02e8e67f5f03fa6458f8921232dc7a9076792d2822ad86f19c3f984fc1a073a8"

--- a/recipes/aws-c-http/all/conanfile.py
+++ b/recipes/aws-c-http/all/conanfile.py
@@ -40,7 +40,11 @@ class AwsCHttp(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "0.10.5":
+        if Version(self.version) >= "0.11.0":
+            self.requires("aws-c-compression/0.3.2")
+            self.requires("aws-c-common/0.14.0", transitive_headers=True, transitive_libs=True)
+            self.requires("aws-c-cal/0.9.14")
+        elif Version(self.version) >= "0.10.5":
             self.requires("aws-c-compression/0.3.1")
             self.requires("aws-c-common/0.12.5", transitive_headers=True, transitive_libs=True)
             self.requires("aws-c-cal/0.9.8")
@@ -51,7 +55,9 @@ class AwsCHttp(ConanFile):
             self.requires("aws-c-compression/0.2.17")
             self.requires("aws-c-common/0.9.6", transitive_headers=True, transitive_libs=True)
 
-        if Version(self.version) >= "0.10.5":
+        if Version(self.version) >= "0.11.0":
+            self.requires("aws-c-io/0.27.0", transitive_headers=True, transitive_libs=True)
+        elif Version(self.version) >= "0.10.5":
             self.requires("aws-c-io/0.23.2", transitive_headers=True, transitive_libs=True)
         elif Version(self.version) <= "0.6.13":
             self.requires("aws-c-io/0.10.20", transitive_headers=True, transitive_libs=True)

--- a/recipes/aws-c-http/config.yml
+++ b/recipes/aws-c-http/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.0":
+    folder: all
   "0.10.5":
     folder: all
   "0.8.1":

--- a/recipes/aws-c-io/all/conandata.yml
+++ b/recipes/aws-c-io/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.27.0":
+    url: "https://github.com/awslabs/aws-c-io/archive/v0.27.0.tar.gz"
+    sha256: "e89a1f784e7c97e4197031ffdcf30f67d66d7c14f8a391edf5764f17dae982ee"
   "0.23.2":
     url: "https://github.com/awslabs/aws-c-io/archive/v0.23.2.tar.gz"
     sha256: "3a335b812411c30bcc64072f148ddf6cd632d8261799cd04e54051b44506feb9"

--- a/recipes/aws-c-io/all/conanfile.py
+++ b/recipes/aws-c-io/all/conanfile.py
@@ -42,7 +42,10 @@ class AwsCIO(ConanFile):
     def requirements(self):
         # the versions of aws-c-common and aws-c-io are tied since aws-c-common/0.6.12 and aws-c-io/0.10.10
         # Please refer https://github.com/conan-io/conan-center-index/issues/7763
-        if Version(self.version) >= "0.23.2":
+        if Version(self.version) >= "0.27.0":
+            self.requires("aws-c-common/0.14.0", transitive_headers=True, transitive_libs=True)
+            self.requires("aws-c-cal/0.9.14", transitive_headers=True, transitive_libs=True)
+        elif Version(self.version) >= "0.23.2":
             self.requires("aws-c-common/0.12.5", transitive_headers=True, transitive_libs=True)
             self.requires("aws-c-cal/0.9.8", transitive_headers=True, transitive_libs=True)
         elif Version(self.version) <= "0.13.4":
@@ -52,7 +55,10 @@ class AwsCIO(ConanFile):
             self.requires("aws-c-common/0.9.6", transitive_headers=True, transitive_libs=True)
             self.requires("aws-c-cal/0.6.9", transitive_headers=True, transitive_libs=True)
 
-        if self.settings.os in ["Linux", "FreeBSD", "Android"]:
+        if Version(self.version) >= "0.27.0":
+            if self.settings.os in ["Linux", "FreeBSD", "Android", "Macos"]:
+                self.requires("s2n/1.7.4")
+        elif self.settings.os in ["Linux", "FreeBSD", "Android"]:
             if Version(self.version) >= "0.23.2":
                 self.requires("s2n/1.6.0")
             else:

--- a/recipes/aws-c-io/config.yml
+++ b/recipes/aws-c-io/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.27.0":
+    folder: all
   "0.23.2":
     folder: all
   "0.13.35":

--- a/recipes/aws-c-mqtt/all/conandata.yml
+++ b/recipes/aws-c-mqtt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.16.0":
+    url: "https://github.com/awslabs/aws-c-mqtt/archive/v0.16.0.tar.gz"
+    sha256: "9bc044a9c2f0d80c384ae6a6907c8817e0b40f673f75c4615c83b20f83140374"
   "0.13.3":
     url: "https://github.com/awslabs/aws-c-mqtt/archive/v0.13.3.tar.gz"
     sha256: "1dfc11d6b3dc1a6d408df64073e8238739b4c50374078d36d3f2d30491d15527"

--- a/recipes/aws-c-mqtt/all/conanfile.py
+++ b/recipes/aws-c-mqtt/all/conanfile.py
@@ -41,7 +41,12 @@ class AwsCMQTT(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "0.13.3":
+        if Version(self.version) >= "0.16.0":
+            self.requires("aws-c-common/0.14.0", transitive_headers=True, transitive_libs=True)
+            self.requires("aws-c-cal/0.9.14")
+            self.requires("aws-c-io/0.27.0", transitive_headers=True)
+            self.requires("aws-c-http/0.11.0")
+        elif Version(self.version) >= "0.13.3":
             self.requires("aws-c-common/0.12.5", transitive_headers=True, transitive_libs=True)
             self.requires("aws-c-cal/0.9.8")
             self.requires("aws-c-io/0.23.2", transitive_headers=True)

--- a/recipes/aws-c-mqtt/config.yml
+++ b/recipes/aws-c-mqtt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.16.0":
+    folder: all
   "0.13.3":
     folder: all
   "0.9.10":

--- a/recipes/aws-c-s3/all/conandata.yml
+++ b/recipes/aws-c-s3/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.12.6":
+    url: "https://github.com/awslabs/aws-c-s3/archive/v0.12.6.tar.gz"
+    sha256: "d70061a523ee1fb6f0127e52653e7cc252347893295d675797b3d387e0e46049"
   "0.9.2":
     url: "https://github.com/awslabs/aws-c-s3/archive/v0.9.2.tar.gz"
     sha256: "70ddd1e69fed7788ff5499b03158f36fb8137d82bd7b1af7bcdf57facbdb1557"

--- a/recipes/aws-c-s3/all/conanfile.py
+++ b/recipes/aws-c-s3/all/conanfile.py
@@ -40,7 +40,10 @@ class AwsCS3(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "0.9.2":
+        if Version(self.version) >= "0.12.6":
+            self.requires("aws-c-common/0.14.0", transitive_headers=True, transitive_libs=True)
+            self.requires("aws-c-cal/0.9.14")
+        elif Version(self.version) >= "0.9.2":
             self.requires("aws-c-common/0.12.5", transitive_headers=True, transitive_libs=True)
             self.requires("aws-c-cal/0.9.8")
         elif Version(self.version) < "0.3.24":
@@ -49,7 +52,11 @@ class AwsCS3(ConanFile):
         else:
             self.requires("aws-c-common/0.9.6", transitive_headers=True, transitive_libs=True)
             self.requires("aws-c-cal/0.6.9")
-        if Version(self.version) >= "0.9.2":
+        if Version(self.version) >= "0.12.6":
+            self.requires("aws-c-auth/0.10.3", transitive_headers=True)
+            self.requires("aws-c-http/0.11.0")
+            self.requires("aws-c-io/0.27.0", transitive_headers=True)
+        elif Version(self.version) >= "0.9.2":
             self.requires("aws-c-auth/0.9.1", transitive_headers=True)
             self.requires("aws-c-http/0.10.5")
             self.requires("aws-c-io/0.23.2", transitive_headers=True)
@@ -65,7 +72,9 @@ class AwsCS3(ConanFile):
             self.requires("aws-c-auth/0.7.8", transitive_headers=True)
             self.requires("aws-c-http/0.7.14")
             self.requires("aws-c-io/0.13.35", transitive_headers=True)
-        if Version(self.version) >= "0.9.2":
+        if Version(self.version) >= "0.12.6":
+            self.requires("aws-checksums/0.2.10")
+        elif Version(self.version) >= "0.9.2":
             self.requires("aws-checksums/0.2.6")
         elif Version(self.version) >= "0.3.24":
             self.requires("aws-checksums/0.1.17")

--- a/recipes/aws-c-s3/config.yml
+++ b/recipes/aws-c-s3/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.12.6":
+    folder: all
   "0.9.2":
     folder: all
   "0.4.5":

--- a/recipes/aws-c-sdkutils/all/conandata.yml
+++ b/recipes/aws-c-sdkutils/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.5":
+    url: "https://github.com/awslabs/aws-c-sdkutils/archive/v0.2.5.tar.gz"
+    sha256: "13a03ea87aa67c7db414bf245fbcc623555c783a34d8ba1d7d701fd42717c366"
   "0.2.4":
     url: "https://github.com/awslabs/aws-c-sdkutils/archive/v0.2.4.tar.gz"
     sha256: "493cbed4fa57e0d4622fcff044e11305eb4fc12445f32c8861025597939175fc"

--- a/recipes/aws-c-sdkutils/all/conanfile.py
+++ b/recipes/aws-c-sdkutils/all/conanfile.py
@@ -40,7 +40,9 @@ class AwsCSDKUtils(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "0.2.4":
+        if Version(self.version) >= "0.2.5":
+            self.requires("aws-c-common/0.14.0", transitive_headers=True, transitive_libs=True)
+        elif Version(self.version) >= "0.2.4":
             self.requires("aws-c-common/0.12.5", transitive_headers=True, transitive_libs=True)
         elif Version(self.version) <= "0.1.3":
             self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)

--- a/recipes/aws-c-sdkutils/config.yml
+++ b/recipes/aws-c-sdkutils/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.5":
+    folder: all
   "0.2.4":
     folder: all
   "0.1.12":

--- a/recipes/aws-checksums/all/conandata.yml
+++ b/recipes/aws-checksums/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.10":
+    url: "https://github.com/awslabs/aws-checksums/archive/v0.2.10.tar.gz"
+    sha256: "cb6509f75e42ee25c372a6d379e8582ce5179e5335183842e808f7d8abb0c314"
   "0.2.6":
     url: "https://github.com/awslabs/aws-checksums/archive/v0.2.6.tar.gz"
     sha256: "e9d94f6f57bfadec7164943aecc4d7d1d8f74b95a626ba5edabfc7df66888cf4"

--- a/recipes/aws-checksums/all/conanfile.py
+++ b/recipes/aws-checksums/all/conanfile.py
@@ -46,7 +46,9 @@ class AwsChecksums(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "0.2.6":
+        if Version(self.version) >= "0.2.10":
+            self.requires("aws-c-common/0.14.0", transitive_headers=True)
+        elif Version(self.version) >= "0.2.6":
             self.requires("aws-c-common/0.12.5", transitive_headers=True)
         elif Version(self.version) < "0.1.17":
             self.requires("aws-c-common/0.8.2")

--- a/recipes/aws-checksums/config.yml
+++ b/recipes/aws-checksums/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.10":
+    folder: all
   "0.2.6":
     folder: all
   "0.1.17":

--- a/recipes/aws-crt-cpp/all/conandata.yml
+++ b/recipes/aws-crt-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.40.1":
+    url: "https://github.com/awslabs/aws-crt-cpp/archive/v0.40.1.tar.gz"
+    sha256: "697a8fb25167e12e704827e360b4f6b1af8ded48e11ef4d185b9cd72e17479c9"
   "0.35.2":
     url: "https://github.com/awslabs/aws-crt-cpp/archive/v0.35.2.tar.gz"
     sha256: "9d53d7018994a5f7fc879d397032b72ad88b1585a8cc07e2c8c339ae427f0577"

--- a/recipes/aws-crt-cpp/all/conanfile.py
+++ b/recipes/aws-crt-cpp/all/conanfile.py
@@ -48,7 +48,18 @@ class AwsCrtCpp(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "0.35":
+        if Version(self.version) >= "0.40.1":
+            self.requires("aws-c-cal/0.9.14", transitive_headers=True)
+            self.requires("aws-c-common/0.14.0", transitive_headers=True)
+            self.requires("aws-checksums/0.2.10")
+            self.requires("aws-c-auth/0.10.3", transitive_headers=True)
+            self.requires("aws-c-event-stream/0.7.1")
+            self.requires("aws-c-http/0.11.0", transitive_headers=True)
+            self.requires("aws-c-io/0.27.0", transitive_headers=True)
+            self.requires("aws-c-mqtt/0.16.0", transitive_headers=True)
+            self.requires("aws-c-s3/0.12.6")
+            self.requires("aws-c-sdkutils/0.2.5")
+        elif Version(self.version) >= "0.35":
             self.requires("aws-c-cal/0.9.8", transitive_headers=True)
             self.requires("aws-c-common/0.12.5", transitive_headers=True)
             self.requires("aws-checksums/0.2.6")

--- a/recipes/aws-crt-cpp/config.yml
+++ b/recipes/aws-crt-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.40.1":
+    folder: all
   "0.35.2":
     folder: all
   "0.24.1":

--- a/recipes/aws-sdk-cpp/all/conandata.yml
+++ b/recipes/aws-sdk-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.11.842":
+    url: "https://github.com/aws/aws-sdk-cpp/archive/1.11.842.tar.gz"
+    sha256: "0e9a43264276898bbe6eb5cd6cc5053e91e87be43b777b06a6e70f1f81ed2cba"
   "1.11.692":
     url: "https://github.com/aws/aws-sdk-cpp/archive/1.11.692.tar.gz"
     sha256: "48af03fe2b19b439344f422015c6f37296920f1972422d94f404001bd9781949"

--- a/recipes/aws-sdk-cpp/all/conanfile.py
+++ b/recipes/aws-sdk-cpp/all/conanfile.py
@@ -341,7 +341,21 @@ class AwsSdkCppConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "1.11":
+        if Version(self.version) >= "1.11.842":
+            self.requires("aws-c-common/0.14.0")
+            self.requires("aws-c-event-stream/0.7.1")
+            self.requires("aws-checksums/0.2.10")
+            self.requires("aws-c-cal/0.9.14")
+            self.requires("aws-c-http/0.11.0")
+            self.requires("aws-c-io/0.27.0")
+            self.requires("aws-c-auth/0.10.3")
+            self.requires("aws-c-compression/0.3.2")
+            self.requires("aws-c-mqtt/0.16.0")
+            self.requires("aws-c-sdkutils/0.2.5")
+            self.requires("aws-crt-cpp/0.40.1", transitive_headers=True)
+            if self.options.get_safe("s3-crt"):
+                self.requires("aws-c-s3/0.12.6")
+        elif Version(self.version) >= "1.11":
             self.requires("aws-c-common/0.12.5")
             self.requires("aws-c-event-stream/0.5.7")
             self.requires("aws-checksums/0.2.6")

--- a/recipes/aws-sdk-cpp/all/conanfile.py
+++ b/recipes/aws-sdk-cpp/all/conanfile.py
@@ -305,7 +305,6 @@ class AwsSdkCppConan(ConanFile):
     default_options["queues"] = True
     default_options["s3-encryption"] = True
     default_options["transfer"] = True
-    default_options["text-to-speech"] = True
 
     short_paths = True
 

--- a/recipes/aws-sdk-cpp/config.yml
+++ b/recipes/aws-sdk-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.11.842":
+    folder: "all"
   "1.11.692":
     folder: "all"
   "1.11.352":

--- a/recipes/s2n/all/conandata.yml
+++ b/recipes/s2n/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.7.4":
+    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.7.4.tar.gz"
+    sha256: "d2fbf45c0e039bdb6f253a392fc8bbdd258bfe0bd586f3516a2c97bb138b8e17"
   "1.6.0":
     url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.6.0.tar.gz"
     sha256: "25f1f14092438d0919d60c4357990e1d2b734e3ffa9d8ecd86590abfd9407b00"

--- a/recipes/s2n/config.yml
+++ b/recipes/s2n/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.7.4":
+    folder: all
   "1.6.0":
     folder: all
   "1.4.16":

--- a/scripts/build-and-push.sh
+++ b/scripts/build-and-push.sh
@@ -200,7 +200,7 @@ for ver, info in (data.get('versions') or {}).items():
 " | while read -r ver folder; do
         recipe="$pkg_dir/$folder/conanfile.py"
         if [ -f "$recipe" ]; then
-            conan export "$recipe" "$pkg_name/$ver@" 2>/dev/null || true
+            conan export "$recipe" --name="$pkg_name" --version="$ver"
         fi
     done
 done


### PR DESCRIPTION
Add the AWS CRT package versions required by aws-sdk-cpp 1.11.842 and wire them into the existing Conan recipes.

 - Register the new source archives and checksums.
 - Select the matching dependency versions while preserving older versions.
 - Add s2n/1.7.4 support for aws-c-io 0.27.0, including macOS.