### PR TITLE
Add milvus-common 1.0.0-1fd1160

### DIFF
--- a/recipes/milvus-common/all/conandata.yml
+++ b/recipes/milvus-common/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0-1fd1160":
+    url: "https://github.com/zilliztech/milvus-common/archive/refs/tags/v1.0.0-1fd1160.tar.gz"
+    sha256: "a76af483b5ec099353546eac2968afbb897a30d35a62781f94537b9cf37658c1"
   "1.0.0-5d2aec9":
     url: "https://github.com/zilliztech/milvus-common/archive/refs/tags/v1.0.0-5d2aec9.tar.gz"
     sha256: "2997aa821e41f7d7441ace464681811bc463414b17f00cfe3fc1a0f557a1264d"

--- a/recipes/milvus-common/config.yml
+++ b/recipes/milvus-common/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0-1fd1160":
+    folder: all
   "1.0.0-5d2aec9":
     folder: all
   "1.0.0-6b16d93":


### PR DESCRIPTION
## Summary
- Add `milvus-common/1.0.0-1fd1160@milvus/dev`.
- Source repo: `zilliztech/milvus-common`.
- Source tag: `v1.0.0-1fd1160`.
- Source commit: `1fd1160625f697e8e45e7507290d88cb18c02a69`.
- Source URL: `https://github.com/zilliztech/milvus-common/archive/refs/tags/v1.0.0-1fd1160.tar.gz`.
- Source SHA256: `a76af483b5ec099353546eac2968afbb897a30d35a62781f94537b9cf37658c1`.
- Verification C++ standard: `20`.

<!-- recipe-verify-cppstd=20 -->

## Validation
- `git diff --check`
- `conan export recipes/milvus-common/all/conanfile.py --version=1.0.0-1fd1160 --user=milvus --channel=dev`