### PR TITLE
fix: Use Conan 2 syntax for local recipe exports

### DIFF
--- a/scripts/build-and-push.sh
+++ b/scripts/build-and-push.sh
@@ -200,7 +200,7 @@ for ver, info in (data.get('versions') or {}).items():
 " | while read -r ver folder; do
         recipe="$pkg_dir/$folder/conanfile.py"
         if [ -f "$recipe" ]; then
-            conan export "$recipe" "$pkg_name/$ver@" 2>/dev/null || true
+            conan export "$recipe" --name="$pkg_name" --version="$ver"
         fi
     done
 done


### PR DESCRIPTION
Pass package names and versions with explicit Conan 2 options so PR verification can resolve dependencies from the local checkout. Surface export failures instead of silently falling through to remotes.