### PR TITLE
feat: add azure-sdk-for-cpp 1.16.1 recipe

### DIFF
--- a/recipes/azure-sdk-for-cpp/all/conandata.yml
+++ b/recipes/azure-sdk-for-cpp/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "1.16.0":
     url: "https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-core_1.16.0.tar.gz"
     sha256: "7f8ba547ef67290075ce148ba1769cf43aa9c7aeed1a62ac5f7ab521f6e68724"
+  "1.16.1":
+    url: "https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-core_1.16.1.tar.gz"
+    sha256: "4d2a85be0a5b7ced9a75cb89434fa6c0712784fb3dfd5d378514197bf9d21e96"

--- a/recipes/azure-sdk-for-cpp/config.yml
+++ b/recipes/azure-sdk-for-cpp/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: "all"
   "1.16.0":
     folder: "all"
+  "1.16.1":
+    folder: "all"


### PR DESCRIPTION
Adds azure-sdk-for-cpp 1.16.1 (azure-core_1.16.1), which is released from the same upstream commit as azure-identity_1.13.1.