### PR TITLE
fix: fetch gnu-config sources from Savannah Git

### DIFF
--- a/recipes/gnu-config/all/conandata.yml
+++ b/recipes/gnu-config/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
   "cci.20210814":
-    url: "http://git.savannah.gnu.org/cgit/config.git/snapshot/config-191bcb948f7191c36eefe634336f5fc5c0c4c2be.tar.gz"
-    sha256: "302e5e7f3c4996976c58efde8b2f28f71d51357e784330eeed738e129300dc33"
+    url: "https://https.git.savannah.gnu.org/git/config.git"
+    commit: "191bcb948f7191c36eefe634336f5fc5c0c4c2be"
   "cci.20201022":
-    url: "http://git.savannah.gnu.org/cgit/config.git/snapshot/config-1c4398015583eb77bc043234f5734be055e64bea.tar.gz"
-    sha256: "339eb64757bf5af9e23ca15daa136acdd9d778753377190ce17fba7e1b222aff"
+    url: "https://https.git.savannah.gnu.org/git/config.git"
+    commit: "1c4398015583eb77bc043234f5734be055e64bea"
 patches:
   "cci.20210814":
     - patch_file: "patches/cci.20210814-0001-tvos-support.patch"

--- a/recipes/gnu-config/all/conanfile.py
+++ b/recipes/gnu-config/all/conanfile.py
@@ -1,7 +1,8 @@
 from conan import ConanFile
 from conan.errors import ConanException
-from conan.tools.files import copy, get, load, save, apply_conandata_patches, export_conandata_patches
+from conan.tools.files import copy, load, save, apply_conandata_patches, export_conandata_patches
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Git
 import os
 
 required_conan_version = ">=1.52.0"
@@ -27,10 +28,12 @@ class GnuConfigConan(ConanFile):
         self.info.clear()
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        git = Git(self)
+        git.fetch_commit(**self.conan_data["sources"][self.version])
+        apply_conandata_patches(self)
 
     def build(self):
-        apply_conandata_patches(self)
+        pass
 
     def _extract_license(self):
         txt_lines = load(self, os.path.join(self.source_folder, "config.guess")).splitlines()


### PR DESCRIPTION
Replace the unavailable Savannah cgit snapshot URLs for cci.20210814 and cci.20201022 with the Git endpoint used by ConanCenter.

Fetch the pinned commits with Git.fetch_commit and apply patches during source() so clean CI builds no longer fail with HTTP 400.