### PR TITLE
feat: add azure-sdk-for-cpp 1.16.4 recipe

### DIFF
--- a/recipes/azure-sdk-for-cpp/all/conandata.yml
+++ b/recipes/azure-sdk-for-cpp/all/conandata.yml
@@ -8,3 +8,6 @@ sources:
   "1.16.1":
     url: "https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-core_1.16.1.tar.gz"
     sha256: "4d2a85be0a5b7ced9a75cb89434fa6c0712784fb3dfd5d378514197bf9d21e96"
+  "1.16.4":
+    url: "https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-core_1.16.4.tar.gz"
+    sha256: "25f8badf23c66ae82debd95e0d074d6269b276e5fa2ce5d4d3cff38fda9ab8c2"

--- a/recipes/azure-sdk-for-cpp/config.yml
+++ b/recipes/azure-sdk-for-cpp/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: "all"
   "1.16.1":
     folder: "all"
+  "1.16.4":
+    folder: "all"


### PR DESCRIPTION
upgrade azure-sdk-for-cpp to 1.16.4

Includes the CURL transport memory leak fix from https://github.com/Azure/azure-sdk-for-cpp/pull/7153.