### PR TITLE
Add milvus-sdk-cpp 2.6.6

### DIFF
--- a/recipes/milvus-sdk-cpp/all/conandata.yml
+++ b/recipes/milvus-sdk-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.6":
+    url: "https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v2.6.6.tar.gz"
+    sha256: "7fb52fb76a0cc4791d0cb97590892da5749001220e5f5586070274a161cdc0d4"
   "3.0.1":
     url: "https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v3.0.1.tar.gz"
     sha256: "bed53bfa652c0654740244aae2a4ba4fdc82c795a732a3f9a30d731b331971b2"

--- a/recipes/milvus-sdk-cpp/config.yml
+++ b/recipes/milvus-sdk-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.6":
+    folder: all
   "3.0.1":
     folder: all
   "2.6.5":


### PR DESCRIPTION
## Summary
- Add `milvus-sdk-cpp/2.6.6@milvus/dev`.
- Source repo: `milvus-io/milvus-sdk-cpp`.
- Source tag: `v2.6.6`.
- Source commit: `9f630df38a55677795fc96d43744d2a6ecf386b8`.
- Source URL: `https://github.com/milvus-io/milvus-sdk-cpp/archive/refs/tags/v2.6.6.tar.gz`.
- Source SHA256: `7fb52fb76a0cc4791d0cb97590892da5749001220e5f5586070274a161cdc0d4`.
- Verification C++ standard: `14`.

<!-- recipe-verify-cppstd=14 -->

## Validation
- `git diff --check`
- `conan export recipes/milvus-sdk-cpp/all/conanfile.py --version=2.6.6 --user=milvus --channel=dev`